### PR TITLE
Bug fix: fatal error "cannot read id of undefined" 

### DIFF
--- a/sound-bubble/imports/ui/components/Account/UserFeed.jsx
+++ b/sound-bubble/imports/ui/components/Account/UserFeed.jsx
@@ -15,19 +15,21 @@ class UserFeed extends Component {
       _id: { $in: myRecentTracks.map(t => t.songId) }
     }).fetch();
 
-    return myRecentTracks.map(t => {
-      let song = songLogs.find(s => s._id === t.songId);
-      let timestamp = t.timestamps;
-      let show = t.show;
-      return (
-        <Song
-          key={song.id + timestamp}
-          song={song}
-          timestamp={timestamp}
-          show={show}
-        />
-      );
-    });
+    if (myRecentTracks.length > 0) {
+      return myRecentTracks.map(t => {
+        let song = songLogs.find(s => s._id === t.songId);
+        let timestamp = t.timestamps;
+        let show = t.show;
+        return (
+          <Song
+            key={song.id + timestamp}
+            song={song}
+            timestamp={timestamp}
+            show={show}
+          />
+        );
+      });
+    }
   }
 
   render() {


### PR DESCRIPTION
- Fatal error "cannot read id of undefined" in UserFeed line 25 when new spotify user (no recently played songs) registers for our app
- fixed by only parsing recently played songs if the length of the array is >0
